### PR TITLE
Add UI links for gists and repos. Closes #35.

### DIFF
--- a/src/components/Home-Stats.css
+++ b/src/components/Home-Stats.css
@@ -29,10 +29,10 @@
     position: relative;
     top: 2px;
     margin-right: 1rem; }
-  .Stats-following > a:link, .Stats-following > a:visited, .Stats-following > a:active, .Stats-followers > a:link, .Stats-followers > a:visited, .Stats-followers > a:active {
+  .Stats-repos > a:link, .Stats-repos > a:visited, .Stats-repos > a:active, .Stats-gists > a:link, .Stats-gists > a:visited, .Stats-gists > a:active, .Stats-following > a:link, .Stats-following > a:visited, .Stats-following > a:active, .Stats-followers > a:link, .Stats-followers > a:visited, .Stats-followers > a:active {
     color: #fff;
     text-decoration: none; }
-  .Stats-following > a:hover > b, .Stats-followers > a:hover > b {
+  .Stats-repos > a:hover > b, .Stats-gists > a:hover > b, .Stats-following > a:hover > b, .Stats-followers > a:hover > b {
     color: #348899;
     text-decoration: none; }
 

--- a/src/components/Home-Stats.js
+++ b/src/components/Home-Stats.js
@@ -77,9 +77,9 @@ class HomeStats extends Component {
     return '?';
   }
 
-  userFollowLink = (follow) => {
+  userTabLink = (tab) => {
     if (this.props.userData && this.props.userData.url) {
-      return `${this.props.userData.url}?tab=${follow}`;
+      return `${this.props.userData.url}?tab=${tab}`;
     }
     return 'https://github.com';
   }
@@ -121,7 +121,7 @@ class HomeStats extends Component {
                 </div>
               </IconContext.Provider>
             </div>
-            <a href={this.userFollowLink('repositories')} target="_blank" rel="noopener noreferrer">
+            <a href={this.userTabLink('repositories')} target="_blank" rel="noopener noreferrer">
               Public Repos: <b>{this.publicReposCount()}</b>
             </a>
           </span>
@@ -145,7 +145,7 @@ class HomeStats extends Component {
                 </div>
               </IconContext.Provider>
             </div>
-            <a href={this.userFollowLink('followers')} target="_blank" rel="noopener noreferrer">
+            <a href={this.userTabLink('followers')} target="_blank" rel="noopener noreferrer">
               Followers: <b>{this.followersCount()}</b>
             </a>
           </span>
@@ -157,7 +157,7 @@ class HomeStats extends Component {
                 </div>
               </IconContext.Provider>
             </div>
-            <a href={this.userFollowLink('following')} target="_blank" rel="noopener noreferrer">
+            <a href={this.userTabLink('following')} target="_blank" rel="noopener noreferrer">
               Following: <b>{this.followingCount()}</b>
             </a>
           </span>

--- a/src/components/Home-Stats.js
+++ b/src/components/Home-Stats.js
@@ -83,6 +83,13 @@ class HomeStats extends Component {
     return 'https://github.com';
   }
 
+  userGistsLink = () => {
+    if (this.props.userData && this.props.userData.login) {
+      return `https://gist.github.com/${this.props.userData.login}`;
+    }
+    return 'https://gist.github.com';
+  }
+
   render() {
     return (
       <div className="Stats col">
@@ -105,7 +112,9 @@ class HomeStats extends Component {
                 </div>
               </IconContext.Provider>
             </div>
-            Public Repos: <b>{this.publicReposCount()}</b>
+            <a href={this.userFollowLink('repositories')} target="_blank" rel="noopener noreferrer">
+              Public Repos: <b>{this.publicReposCount()}</b>
+            </a>
           </span>
           <span className="Stats-gists">
             <div className="Stats-icon">
@@ -115,7 +124,9 @@ class HomeStats extends Component {
                 </div>
               </IconContext.Provider>
             </div>
-            Public Gists: <b>{this.publicGistsCount()}</b>
+            <a href={this.userGistsLink()} target="_blank" rel="noopener noreferrer">
+              Public Gists: <b>{this.publicGistsCount()}</b>
+            </a>
           </span>
           <span className="Stats-followers">
             <div className="Stats-icon">

--- a/src/components/Home-Stats.scss
+++ b/src/components/Home-Stats.scss
@@ -33,7 +33,7 @@
     top: 2px;
     margin-right: 1rem;
   }
-  &-following, &-followers {
+  &-repos, &-gists, &-following, &-followers {
     > a {
       &:link, &:visited, &:active {
         color: $white;


### PR DESCRIPTION
This PR adds functionality requested in #35. You can now click links to view the users' public repos and public gists. These open in a new tab.