### PR TITLE
Simplify npm run / env developer flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,22 @@ NodeJs, ExpressJs backend for this project is located here: https://github.com/t
 
 ## Run
 
-`npm run start`
+If you are only working on this project and **not** the backend project:
+```
+npm run ui-only
+```
 
-`npm run watch-css` (separate window)
+Otherwise if you're also running the backend:
+```
+npm run start
+```
 
 ## Styling
 
 Sass is used for styling. All `.scss` files are compliled into `.css` in the same directory.
 
 ## Environment
+**Note**: Environment variables are taken care of if using either of the `npm run` commands above
 
 | Name | Description | Example |
 |------|-------------|--------|

--- a/README.md
+++ b/README.md
@@ -15,22 +15,13 @@ NodeJs, ExpressJs backend for this project is located here: https://github.com/t
 
 ## Run
 
-If you are only working on this project and **not** the backend project:
-```
-npm run ui-only
-```
-
-Otherwise if you're also running the backend:
-```
-npm run start
-```
+`npm run start`
 
 ## Styling
 
 Sass is used for styling. All `.scss` files are compliled into `.css` in the same directory.
 
 ## Environment
-**Note**: Environment variables are taken care of if using either of the `npm run` commands above
 
 | Name | Description | Example |
 |------|-------------|--------|

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-scripts": "1.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "ui-only": "export REACT_APP_API_URL=https://githubprofilesummary.appspot.com/api/v1; concurrently \"react-scripts start\" \"npm run watch-css\"",
+    "start": "export REACT_APP_API_URL=http://localhost:3003/api/v1; concurrently \"react-scripts start\" \"npm run watch-css\"",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "react-scripts": "1.1.4"
   },
   "scripts": {
-    "ui-only": "export REACT_APP_API_URL=https://githubprofilesummary.appspot.com/api/v1; concurrently \"react-scripts start\" \"npm run watch-css\"",
-    "start": "export REACT_APP_API_URL=http://localhost:3003/api/v1; concurrently \"react-scripts start\" \"npm run watch-css\"",
+    "start": "concurrently \"react-scripts start\" \"npm run watch-css\"",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Hi, I noticed that `concurrently` is being used as a dependency, so I thought I might as well suggest this change

Currently, after running `npm install`, the steps for a new / returning developer can end up being:
1. Change the `REACT_APP_API_URL` env var
2. Run `npm run start`
3. Start a new terminal session and `npm run watch-css`

With this change, restarting development is just one step:
1. run either `npm run ui-only` or `npm run start`

I've tested that changing either the SCSS or JS will successfully update the browser page.   
Feel free to reject this PR if this isn't how you'd like the flow to be!