### PR TITLE
Improve alignment of date with tags; add space after colon

### DIFF
--- a/src/components/Home-Repos.css
+++ b/src/components/Home-Repos.css
@@ -35,7 +35,6 @@
       color: #fff; }
     .Repos-repo-updated {
       margin-left: auto;
-      margin-right: 0.5rem;
       text-align: right;
       color: #fff; }
     .Repos-repo-languages {

--- a/src/components/Home-Repos.css
+++ b/src/components/Home-Repos.css
@@ -17,10 +17,11 @@
     border-radius: 4px;
     cursor: pointer; }
     .Repos-repo-icon {
-      position: relative;
-      top: 2px;
       margin-left: 0.5rem;
       margin-right: 1rem; }
+      .Repos-repo-icon.stay {
+        position: relative;
+        top: 2px; }
       .Repos-repo-icon svg {
         fill: #fff; }
     .Repos-repo-name {
@@ -31,10 +32,12 @@
         color: #54b2c5; }
     .Repos-repo-stars {
       padding-top: 0.25rem;
+      margin-bottom: 4px;
       margin-left: 0.5rem;
       color: #fff; }
     .Repos-repo-updated {
       margin-left: auto;
+      margin-right: 0.5rem;
       text-align: right;
       color: #fff; }
     .Repos-repo-languages {

--- a/src/components/Home-Repos.js
+++ b/src/components/Home-Repos.js
@@ -56,7 +56,7 @@ class HomeRepos extends Component {
     return (
       <div className="Repos-repo" key={ index } onClick={ () => this.repoClicked(index) }>
         <IconContext.Provider value={ {} }>
-          <div className="Repos-repo-icon">
+          <div className="Repos-repo-icon stay">
             <GoRepo />
           </div>
         </IconContext.Provider>
@@ -73,7 +73,8 @@ class HomeRepos extends Component {
         </IconContext.Provider>
 
         <div className="Repos-repo-updated">
-          Last Updated:&nbsp;
+          Last Updated:
+          {' '}
           <b>{dateFormatted}</b>
         </div>
         {this.createLanguages(node.languages.edges)}

--- a/src/components/Home-Repos.js
+++ b/src/components/Home-Repos.js
@@ -73,7 +73,7 @@ class HomeRepos extends Component {
         </IconContext.Provider>
 
         <div className="Repos-repo-updated">
-Last Updated:
+          Last Updated:&nbsp;
           <b>{dateFormatted}</b>
         </div>
         {this.createLanguages(node.languages.edges)}

--- a/src/components/Home-Repos.scss
+++ b/src/components/Home-Repos.scss
@@ -13,11 +13,13 @@
     cursor: pointer;
 
     &-icon {
-      position: relative;
-      top: 2px;
       margin-left: 0.5rem;
       margin-right: 1rem;
 
+      &.stay {
+        position: relative;
+        top: 2px;
+      }
       svg {
         fill: $white;
       }
@@ -33,6 +35,7 @@
     }
     &-stars {
       padding-top: 0.25rem;
+      margin-bottom: 4px;
       margin-left: 0.5rem;
       color: $white;
     }


### PR DESCRIPTION
Second row in this picture has the changes.

![screen shot 2018-10-04 at 3 59 24 pm](https://user-images.githubusercontent.com/7636254/46499692-beadb880-c7ee-11e8-965b-242e6c87e0b0.png)


